### PR TITLE
Shorten link text with markdown

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -12,7 +12,7 @@ var addCard = function(num, title, bdesc, link) {
     else {
         var name = num + " - " + title;
     }
-    var desc = link + '\n\n' + bdesc;
+    var desc = '[' + (num ? num : name) + '](' + link + ')\n\n' + bdesc;
     Trello.post("cards", {
         name: name,
         desc: desc,


### PR DESCRIPTION
I would like to use just the issue number as link text, and fall back to the name if there is no number.

I've tested that the markdown works in trello; while I haven't built the extension locally, the change is simple enough, that I'm mostly fure it's good.

cheers